### PR TITLE
Reworks the process-blocks job to process blocks in chunks

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -15,9 +15,10 @@ const fullConfig = {
       logLevel: 'silly',
     },
     blockchain: {
-      minConfirmations: 0,
       startingBlockHeight: 0,
       averageBlockTime: 15, // in seconds, this dictates how frequently to run agenda jobs
+      minConfirmations: 0,
+      chunkSize: 50000, // max number of blocks to request each time the process-blocks job is run
     },
   },
 
@@ -27,9 +28,10 @@ const fullConfig = {
       logLevel: 'verbose',
     },
     blockchain: {
-      minConfirmations: 5,
       startingBlockHeight: 3436527,
       averageBlockTime: 15, // in seconds, this dictates how frequently to run agenda jobs
+      minConfirmations: 5,
+      chunkSize: 50000, // max number of blocks to request each time the process-blocks job is run
     },
   },
 
@@ -39,9 +41,10 @@ const fullConfig = {
       logLevel: 'info',
     },
     blockchain: {
-      minConfirmations: 8,
-      startingBlockHeight: 5999924,
+      startingBlockHeight: 6000000,
       averageBlockTime: 15, // in seconds, this dictates how frequently to run agenda jobs
+      minConfirmations: 8,
+      chunkSize: 50000, // max number of blocks to request each time the process-blocks job is run
     },
   },
 }


### PR DESCRIPTION
This PR updates the process-blocks job so that large amounts of block processing doesn't lock up the server and crash the process. Events are now retrieved for large chunks of blocks instead of processing blocks one-by-one. With a chunk size of 50,000 blocks, it takes about 1.5 mins to rebuild the EEL database. Any more than that and Infura will choke.

Note that this doesn't really help Biddable or the Registry API, because those applications rely on data being in the database while processing events so there isn't really a concept of "rebuilding the database from scratch."