### PR TITLE
Reduce mainnet confirmations to 2

### DIFF
--- a/src/config/mainnet.js
+++ b/src/config/mainnet.js
@@ -5,7 +5,7 @@ export default {
   blockchain: {
     startingBlockHeight: 6000000,
     averageBlockTime: 15, // in seconds, this dictates how frequently to run agenda jobs
-    minConfirmations: 8,
+    minConfirmations: 2,
     chunkSize: 50000, // max number of blocks to request each time the process-blocks job is run
   },
 }


### PR DESCRIPTION
We haven't seen any issues w/ Ropsten or Rinkeby at 1. Let's reduce Mainnet to 2 to make things a little snappier for users. MetaMask is giving notifications at 1 confirmation so it's a bit weird to get one notification quickly and then have to wait 3 minutes for the other.